### PR TITLE
Adding support for `az login --identity`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -22,4 +22,23 @@ app.MapGet("/token", async (HttpContext context, string resource) =>
     };
 });
 
+// Can be consumed by "az login --identity" by specifying MSI_ENDPOINT environment variable to this action URL
+// https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py#L474
+
+app.MapPost("/token", async (HttpContext context, HttpRequest request) =>
+{
+    var form = await request.ReadFormAsync();
+    string resource = form["resource"].ToString();
+    var token = await tokenCredential.GetTokenAsync(new TokenRequestContext(new[] { resource }));
+    context.Response.Headers.Add("Content-Type", "application/json"); // Set the Content-Type header to JSON
+    return new Dictionary<string, string>
+    {
+        ["access_token"] = token.Token,
+        ["expiresOn"] = token.ExpiresOn.ToString("O", CultureInfo.InvariantCulture),
+        ["expires_on"] = token.ExpiresOn.ToUnixTimeSeconds().ToString(),
+        ["token_type"] = "Bearer",
+        ["resource"] = resource
+    };
+});
+
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ app.MapGet("/token", async (HttpContext context, string resource) =>
 app.MapPost("/token", async (HttpContext context, HttpRequest request) =>
 {
     var form = await request.ReadFormAsync();
-    string resource = form["resource"].ToString();
+    var resource = form["resource"].ToString();
     var token = await tokenCredential.GetTokenAsync(new TokenRequestContext(new[] { resource }));
     context.Response.Headers.Add("Content-Type", "application/json"); // Set the Content-Type header to JSON
     return new Dictionary<string, string>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ services:
     environment:
       - "IDENTITY_ENDPOINT=http://azclicredsproxy:8080/token"
       - "IMDS_ENDPOINT=dummy_required_value"
+      # Specify MSI_ENDPOINT below if using "az login --identity" in your service.
+      - "MSI_ENDPOINT=http://azclicredsproxy:8080/token"
 ```
 
 
@@ -64,6 +66,9 @@ Then, we must add two environment variables to each service:
 * `IMDS_ENDPOINT`: an arbitrary but mandatory value (e.g., `random-placeholder`)
 
 With these two environment variables, any service that uses `DefaultAzureCredential` or `ManagedIdentityCredential` will now call the proxy when Azure credentials are needed. This is because one of `ManagedIdentityCredential`'s [source implementations](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Identity_1.6.0/sdk/identity/Azure.Identity/src/AzureArcManagedIdentitySource.cs) explicitly looks for both of these environment variables if they are specified.
+
+> [!NOTE]
+> If you are using using `az cli` in your service and your service wants to do `az login --identity` then specify `MSI_ENDPOINT`: the URL of the proxy endpoint (e.g., `http://azclicredsproxy:8080/token`) environment variable instead. `IDENTITY_ENDPOINT` and `IMDS_ENDPOINT` are not required for `az login --identity`.
 
 With this proxy, Dockerfiles can remain untouched and production-ready. The proxy can easily be added to an existing `docker-compose.yml`, and the environment variables are also easy to add. Now, the containerized environment looks like this:
 


### PR DESCRIPTION
Was trying to use this container in a scenario where our service container uses az cli and would do `az login --identity` when running in Azure and would like the same to work in a local development environment also. Working backwards from https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py#L474 added support for enabling this scenario.